### PR TITLE
Add "events" event from dota gsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Don't forget to replace asterisk `*` with your name.
         "items"         "1"
         "draft"         "1"
         "wearables"     "1"
+        "events"        "1"
     }
 }
 ```

--- a/src/dota2/Dota2GSIServer.ts
+++ b/src/dota2/Dota2GSIServer.ts
@@ -10,6 +10,7 @@ import {
   IProvider,
   IWearbleItem,
   TeamType,
+  IEvent,
 } from './interface';
 
 import {
@@ -21,6 +22,7 @@ import {
   decodeMap,
   decodePlayer,
   decodeWearable,
+  decodeEvents,
 } from './decoders';
 import { checkKey } from './utils';
 
@@ -149,6 +151,11 @@ export class Dota2GSIServer extends GSIServer {
       }
     }
 
+    let events = null;
+    if (checkKey(rawState, 'events')) {
+      events = decodeEvents(rawState['events']);
+    }
+
     return {
       buildings,
       provider,
@@ -159,6 +166,7 @@ export class Dota2GSIServer extends GSIServer {
       items,
       draft,
       wearables,
+      events,
     };
   }
 }

--- a/src/dota2/decoders.ts
+++ b/src/dota2/decoders.ts
@@ -2,6 +2,7 @@ import {
   IAbility,
   IBuilding,
   IDraft,
+  IEvent,
   IHero,
   IItem,
   IItemContainer,
@@ -257,4 +258,13 @@ export function decodeWearable(rawWearable: any) {
     iWearableList.push(item);
   });
   return iWearableList as IWearbleItem[];
+}
+
+export function decodeEvents(rawEvents: Array<any>) {
+  return rawEvents.map((event) => {
+    return { 
+      gameTime: getAttr(event, 'game_time'),
+      eventType: getAttr(event, 'event_type'), 
+    } as IEvent
+  });
 }

--- a/src/dota2/interface.ts
+++ b/src/dota2/interface.ts
@@ -18,6 +18,12 @@ export enum Dota2GameState {
   PostGame = 'DOTA_GAMERULES_STATE_POST_GAME',
 }
 
+export enum EventType {
+  AegisPickedUp = 'aegis_picked_up',
+  BountyRunePickedUp = 'bounty_rune_pickup',
+  RoshanKilled = 'roshan_killed',
+}
+
 export interface IDota2StateEvent {
   state: IDota2State;
   changes: IDota2State;
@@ -31,6 +37,7 @@ export interface IDota2ObserverStateEvent {
 export interface IDota2BaseState {
   buildings: IBuildings | null;
   provider: IProvider | null;
+  events: IEvent[] | null;
 }
 
 export interface IDota2State extends IDota2BaseState {
@@ -205,4 +212,9 @@ export interface IPickBan {
 export interface IWearbleItem {
   wearable: number;
   style?: number;
+}
+
+export interface IEvent {
+  gameTime: number;
+  eventType: EventType;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { BasicEvent } from './GSIServer';
 export {
   Dota2GameState,
   Dota2Event,
+  EventType,
   IAbility,
   IBuilding,
   IBuildings,
@@ -10,6 +11,7 @@ export {
   IDota2StateEvent,
   IDota2ObserverState,
   IDota2ObserverStateEvent,
+  IEvent,
   IHero,
   IItem,
   IItemContainer,


### PR DESCRIPTION
Hello!

I wanted to use your library to write an app that consumes roshan killed events but noticed you do not have that yet so here's a pull request. 

I'm new to TypeScript so I had some questions and concerns about my code (see comment inline) before you merge. I'm happy to make any changes based on whatever feedback you have

Note: the gsi config file needs to include “events” for this to work

Examples of rawEvents
```
[
  {
    game_time: 260,
    event_type: 'bounty_rune_pickup',
    player_id: 0,
    team: 'radiant',
    bounty_value: 40,
    team_gold: 200
  },
  {
    game_time: 260,
    event_type: 'bounty_rune_pickup',
    player_id: 6,
    team: 'dire',
    bounty_value: 40,
    team_gold: 200
  },
  {
    game_time: 260,
    event_type: 'bounty_rune_pickup',
    player_id: 3,
    team: 'radiant',
    bounty_value: 40,
    team_gold: 200
  },
  {
    game_time: 259,
    event_type: 'bounty_rune_pickup',
    player_id: 5,
    team: 'dire',
    bounty_value: 40,
    team_gold: 200
  }
]
```
```
[
  {
    game_time: 1856,
    event_type: 'roshan_killed',
    killed_by_team: 'radiant',
    killer_player_id: 4
  },
  {
    game_time: 1857,
    event_type: 'aegis_picked_up',
    player_id: 3,
    snatched: false
  }
]
```